### PR TITLE
StoreHashAccessor fix interface for rails 8+

### DIFF
--- a/lib/active_typed_store/disallow_symbol_keys.rb
+++ b/lib/active_typed_store/disallow_symbol_keys.rb
@@ -19,7 +19,7 @@ module ActiveTypedStore
 
   # Same interface as ActiveRecord::Store::HashAccessor
   # Optimized by using object.read_attribute(attribute) instead of object.send(attribute)
-  class StoreHashAccessor
+  class StoreHashAccessor < ActiveRecord::Store::StringKeyedHashAccessor
     def self.read(object, attribute, key)
       prepare(object, attribute)
       object.read_attribute(attribute)[key]

--- a/spec/active_typed_store_spec.rb
+++ b/spec/active_typed_store_spec.rb
@@ -149,6 +149,19 @@ RSpec.describe ActiveTypedStore do
       expect { m.settings[:foo] }.to raise_error(ActiveTypedStore::SymbolKeysDisallowed)
       expect { m.params["settings"][:foo] }.to raise_error(ActiveTypedStore::SymbolKeysDisallowed)
     end
+
+    it "dirty-like methods" do
+      m = model.create(name: "name")
+      m.name = "another name"
+
+      expect(m.name_change).to eq(["name", "another name"])
+      expect(m.name_was).to eq("name")
+
+      m.save!
+      expect(m.saved_change_to_name).to eq(["name", "another name"])
+      expect(m.saved_change_to_name?).to be true
+      expect(m.name_before_last_save).to eq("name")
+    end
   end
 
   context "when active model type" do


### PR DESCRIPTION
В 8 рельсе унифицировали чтение значения из store_object (хэш), учитывая что он может быть nil. Добавили метод get() в базовый класс ActiveRecord::Store::HashAccessor и другие наследуемые от него интерфейсы. 
У нас используется наш StoreHashAccessor, который копирует интерфейс ActiveRecord::Store::HashAccessor и оптимизирует методы, но наследуется от него. Если меняется интерфейс, наш код остается старым. 

Сейчас на 8 рельсе не работают dirty-like методы(они используют новый геттер get())
```
#{key}_change
#{key}_was
saved_change_to_#{key}?
saved_change_to_#{key}
#{key}_before_last_save 
```

```
a = GuestUser.last
a.phone = '123123123'
a.save
a.saved_change_to_phone? # ошибка
(gp-app):6:in '<main>': undefined method 'get' for class ActiveTypedStore::StoreHashAccessor (NoMethodError)
```

Решил добавить наследования для нашего StoreHashAccessor от StringKeyedHashAccessor(используется для json атрибутов), чтобы был фолбек на стандартный интерфейс. 

Код из рельсы:
```
class StringKeyedHashAccessor < HashAccessor # :nodoc:
        def self.get(store_object, key)
          super store_object, Symbol === key ? key.name : key.to_s
        end

        def self.read(object, attribute, key)
          super object, attribute, Symbol === key ? key.name : key.to_s
        end

        def self.write(object, attribute, key, value)
          super object, attribute, Symbol === key ? key.name : key.to_s, value
        end
      end
```